### PR TITLE
local_path is relevant to Vagrantfile

### DIFF
--- a/ansible/group_vars/development
+++ b/ansible/group_vars/development
@@ -6,7 +6,7 @@ wordpress_sites:
   roots-example-project.com:
     site_hosts:
       - roots-example-project.dev
-    local_path: '../site' # path targeting local Bedrock project directory (relative to Ansible root)
+    local_path: 'site' # path targeting local Bedrock project directory (relative to VagrantFile)
     repo: git@github.com:roots/bedrock.git
     site_install: true
     site_title: Example Site


### PR DESCRIPTION
In my local installation that mimics this setup, local_path has to be relative to the location of the Vagrantfile, not the Ansible folder.
