### PR TITLE
Update README.md to mention ANSIBLE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's how this example project was created:
 2. Clone bedrock-ansible: `$ git clone --depth=1 git@github.com:roots/bedrock-ansible.git ansible && rm -rf ansible/.git`
 3. Clone Bedrock: `$ git clone --depth=1 git@github.com:roots/bedrock.git site && rm -rf site/.git`
 4. Clone Sage: `$ git clone --depth=1 git@github.com:roots/sage.git site/web/app/themes/sage && rm -rf site/web/app/themes/sage/.git`
-5. Move `Vagrantfile` to root: `$ mv ansible/Vagrantfile .`
+5. Move `Vagrantfile` to root: `$ mv ansible/Vagrantfile .` and update the [ANSIBLE_PATH](https://github.com/roots/roots-example-project.com/blob/master/Vagrantfile#L6) to `'ansible'`
 
 After that your folder structure is complete and you're ready to configure the individual components.
 


### PR DESCRIPTION
By following the installation instructions in this readme the ANSIBLE_PATH in the Vagrantfile [defaults to `'.'`](https://github.com/roots/bedrock-ansible/blob/master/Vagrantfile#L9) and gives the following error on `vagrant up`:

```
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /roots-example-project/Vagrantfile
Message: ./group_vars/development file not found. Please set `ANSIBLE_PATH` in Vagrantfile
```

This PR updates the readme to include instructions to change the ANSIBLE_PATH in the Vagrantfile
