### PR TITLE
Fix README: use absolute path for ANSIBLE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's how this example project was created:
 2. Clone Trellis: `$ git clone --depth=1 git@github.com:roots/trellis.git ansible && rm -rf ansible/.git`
 3. Clone Bedrock: `$ git clone --depth=1 git@github.com:roots/bedrock.git site && rm -rf site/.git`
 4. Clone Sage: `$ git clone --depth=1 git@github.com:roots/sage.git site/web/app/themes/sage && rm -rf site/web/app/themes/sage/.git`
-5. Move `Vagrantfile` to root: `$ mv ansible/Vagrantfile .` and update the [ANSIBLE_PATH](https://github.com/roots/roots-example-project.com/blob/master/Vagrantfile#L6) to `'ansible'`
+5. Move `Vagrantfile` to root: `$ mv ansible/Vagrantfile .` and update the [ANSIBLE_PATH](https://github.com/roots/roots-example-project.com/blob/master/Vagrantfile#L6) to `File.join(__dir__, 'ansible')`
 
 After that your folder structure is complete and you're ready to configure the individual components.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require 'yaml'
 
-ANSIBLE_PATH = 'ansible' # path targeting Ansible directory (relative to Vagrantfile)
+ANSIBLE_PATH = File.join(__dir__, 'ansible') # absolute path to Ansible directory
 
 # Set Ansible roles_path relative to Ansible directory
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')


### PR DESCRIPTION
To be consistent with roots/trellis#257 and prevent issues like https://discourse.roots.io/t/vagrant-global-status-error/4417
