### PR TITLE
Update README.md to include requirements for Sage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,18 @@ You can view it at http://roots-example-project.com/.
 
 ## Requirements
 
-Make sure all dependencies have been installed before moving on:
+Make sure you have installed all of the dependencies for [Trellis](https://github.com/roots/trellis#requirements), [Bedrock](https://github.com/roots/bedrock#requirements) and [Sage](https://github.com/roots/sage#requirements) before moving on.
+
+At a minimum you need to have:
 
 * [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) >= 2.0.0.2
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
 * [Vagrant](http://www.vagrantup.com/downloads.html) >= 1.5.4
 * [vagrant-bindfs](https://github.com/gael-ian/vagrant-bindfs#installation) >= 0.3.1 (Windows users may skip this)
 * [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager#installation)
+* [Node.js](http://nodejs.org/) >= 0.12.x
+* [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md) >= 3.8.10
+* [Bower](https://github.com/bower/bower/blob/master/README.md#install) >= 1.3.12
 
 ## Instructions
 


### PR DESCRIPTION
Reading through https://discourse.roots.io/t/roots-example-project-php-7-error-notices-and-composer/6898 I started to think this readme should include Composer, however it's possible to use Trellis' version instead of installing it globally on your host machine.

What is required though is Node + Gulp + Bower for Sage 8, so I've added them here, as well as a line that you should install the requirements for each project first.
