### PR TITLE
Add roots/wordpress version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roots Example Project
 
-[![Roots](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/roots/roots-example-project.com/master/site/composer.json?token=R2l0SHViIFRva2VuIEdvZXMgSGVyZQ==&label=wordpress&logo=roots&logoColor=white&query=$.require["roots/wordpress"]&colorB=2b3072&colorA=525ddc)](//roots.io)
+[![Roots](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/roots/roots-example-project.com/master/site/composer.json&label=wordpress&logo=roots&logoColor=white&query=$.require["roots/wordpress"]&colorB=2b3072&colorA=525ddc)](//roots.io)
 
 This repository is an example of how to integrate and use the following projects together:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Roots Example Project
 
+[![Roots](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/roots/roots-example-project.com/master/site/composer.json?token=R2l0SHViIFRva2VuIEdvZXMgSGVyZQ==&label=wordpress&logo=roots&logoColor=white&query=$.require["roots/wordpress"]&colorB=2b3072&colorA=525ddc)](//roots.io)
+
 This repository is an example of how to integrate and use the following projects together:
 
 * [Bedrock](https://github.com/roots/bedrock)


### PR DESCRIPTION
Might be a nice addition to the README, however, it will expose an outdated version if the repo isn’t kept up to date which isn’t necessarily a bad thing.